### PR TITLE
Enable configurable multi-service FHIR routing

### DIFF
--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Application/Interfaces/IFhirApiService.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Application/Interfaces/IFhirApiService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ship.Ses.Transmitter.Application.Sync
@@ -11,11 +12,12 @@ namespace Ship.Ses.Transmitter.Application.Sync
     public interface IFhirApiService
     {
         public Task<FhirApiResponse> SendAsync(
-        FhirOperation operation,
-        string resourceType,
-        string resourceId = null,
-        string jsonPayload = null,
-        string? callbackUrl = null,
-        CancellationToken cancellationToken = default);
+            FhirOperation operation,
+            string resourceType,
+            string resourceId = null,
+            string jsonPayload = null,
+            string? callbackUrl = null,
+            string? shipService = null,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Domain/Sync/StatusEvent.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Domain/Sync/StatusEvent.cs
@@ -74,6 +74,8 @@ namespace Ship.Ses.Transmitter.Domain.Sync
         public string? ClientId { get; set; }
         [BsonElement("facilityId")]
         public string? FacilityId { get; set; }
+        [BsonElement("shipService")]
+        public string? ShipService { get; set; }
         [BsonElement("probeStatus")]
         public string? ProbeStatus { get; set; } = "Pending"; // Pending|InFlight|Succeeded|Abandoned
 

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/Installers/WorkerServiceExtensions.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/Installers/WorkerServiceExtensions.cs
@@ -134,34 +134,19 @@ namespace Ship.Ses.Transmitter.Infrastructure.Installers
         }
         public static IServiceCollection AddFhirApiClient(this IServiceCollection services, IConfiguration config)
         {
-            services.Configure<FhirApiSettings>(config.GetSection("FhirApi"));
-            //Console.WriteLine("FhirApiSettings: " + config.GetSection("FhirApi").Value);
-            var fhirApiSection = config.GetSection("FhirApi");
-            //Console.WriteLine($"  BaseUrl: {fhirApiSection["BaseUrl"]}");
-            //Console.WriteLine($"  ClientCertPath: {fhirApiSection["ClientCertPath"]}");
-            //Console.WriteLine($"  ClientCertPassword: {fhirApiSection["ClientCertPassword"]}");
-
             services.AddHttpClient("FhirApi", (sp, client) =>
             {
-                var settings = sp.GetRequiredService<IOptions<FhirApiSettings>>().Value;
-                client.BaseAddress = new Uri(settings.BaseUrl);
-                client.Timeout = TimeSpan.FromSeconds(settings.TimeoutSeconds);
+                var routing = sp.GetRequiredService<IOptionsMonitor<FhirRoutingSettings>>().CurrentValue;
+                var defaults = routing.Default ?? new FhirRouteSettings();
+
+                if (!string.IsNullOrWhiteSpace(defaults.BaseUrl))
+                {
+                    client.BaseAddress = new Uri(defaults.BaseUrl);
+                }
+
+                var timeout = defaults.TimeoutSeconds > 0 ? defaults.TimeoutSeconds : 30;
+                client.Timeout = TimeSpan.FromSeconds(timeout);
             })
-            //temporarily disable client certificate handling
-            //.ConfigurePrimaryHttpMessageHandler(sp =>
-            //{
-            //    var settings = sp.GetRequiredService<IOptions<FhirApiSettings>>().Value;
-            //    var certPath = Path.Combine(AppContext.BaseDirectory, settings.ClientCertPath);
-            //    var cert = new X509Certificate2(certPath, settings.ClientCertPassword);
-
-            //    var handler = new HttpClientHandler
-            //    {
-            //        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-            //    };
-
-            //    handler.ClientCertificates.Add(cert);
-            //    return handler;
-            //})
             .AddPolicyHandler(GetRetryPolicy())
             .AddPolicyHandler(GetCircuitBreakerPolicy());
 

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/ReadServices/FhirSyncService.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/ReadServices/FhirSyncService.cs
@@ -1,7 +1,6 @@
 ﻿using AngleSharp.Io;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
@@ -13,7 +12,6 @@ using Ship.Ses.Transmitter.Domain.Patients;
 using Ship.Ses.Transmitter.Domain.Sync;
 using Ship.Ses.Transmitter.Infrastructure.Persistance.MySql;
 using Ship.Ses.Transmitter.Infrastructure.Services;
-using Ship.Ses.Transmitter.Infrastructure.Settings;
 using Ship.Ses.Transmitter.Infrastructure.Shared;
 using System;
 using System.Collections.Generic;
@@ -28,16 +26,14 @@ namespace Ship.Ses.Transmitter.Infrastructure.ReadServices
         private readonly IMongoSyncRepository _repository;
         private readonly ILogger<FhirSyncService> _logger;
         private readonly IFhirApiService _fhirApiService;
-        private readonly IOptionsMonitor<FhirApiSettings> _apiSettings;
         private readonly IStagingUpdateWriter _stagingUpdateWriter;
 
         public FhirSyncService(IMongoSyncRepository repository, ILogger<FhirSyncService> logger, IFhirApiService fhirApiService, 
-            IOptionsMonitor<FhirApiSettings> apiSettings, IStagingUpdateWriter stagingUpdateWriter)
+            IStagingUpdateWriter stagingUpdateWriter)
         {
             _repository = repository;
             _logger = logger;
             _fhirApiService = fhirApiService;
-            _apiSettings = apiSettings;
             _stagingUpdateWriter = stagingUpdateWriter;
         }
 
@@ -86,6 +82,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.ReadServices
                         record.ResourceId,
                         record.FhirJson.ToCleanJson(),
                         record.ClientEMRCallbackUrl,
+                        record.ShipService,
                         token);
 
                     var accepted = apiResponse != null
@@ -124,6 +121,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.ReadServices
                                     CorrelationId = record.CorrelationId ?? string.Empty,
                                     FacilityId = record.FacilityId ?? string.Empty,
                                     ClientId = record.ClientId,
+                                    ShipService = record.ShipService,
 
                                     // --- Probe fields
                                     ProbeStatus = "Pending",

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/ReadServices/TokenService.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/ReadServices/TokenService.cs
@@ -36,14 +36,20 @@ namespace Ship.Ses.Transmitter.Infrastructure.ReadServices
 
 
         }
-        public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+        public Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+            => GetAccessTokenAsync(null, cancellationToken);
+
+        public async Task<string> GetAccessTokenAsync(string? scopeOverride, CancellationToken cancellationToken = default)
         {
+            var scopeToUse = string.IsNullOrWhiteSpace(scopeOverride) ? _authSettings.Scope : scopeOverride;
+            scopeToUse ??= string.Empty;
+
             var payloadObj = new
             {
                 clientId = _authSettings.ClientId,
                 clientSecret = _authSettings.ClientSecret,
                 grantType = string.IsNullOrWhiteSpace(_authSettings.GrantType) ? "client_credentials" : _authSettings.GrantType,
-                scope = _authSettings.Scope
+                scope = scopeToUse
             };
 
             var jsonPayload = JsonSerializer.Serialize(payloadObj, new JsonSerializerOptions
@@ -58,7 +64,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.ReadServices
             req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             _logger.LogInformation("🔐 Requesting access token: endpoint={Endpoint}, client_id={ClientId}, scope={Scope}",
-                _authSettings.TokenEndpoint, Mask(_authSettings.ClientId), _authSettings.Scope);
+                _authSettings.TokenEndpoint, Mask(_authSettings.ClientId), scopeToUse);
 
             using var resp = await _httpClient.SendAsync(req, cancellationToken);
             var body = await resp.Content.ReadAsStringAsync(cancellationToken);

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/Settings/FhirRoutingSettings.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/Settings/FhirRoutingSettings.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ship.Ses.Transmitter.Infrastructure.Settings
+{
+    public sealed class FhirRoutingSettings
+    {
+        public FhirRouteSettings Default { get; set; } = new();
+        public List<FhirApiRouteSettings> Apis { get; set; } = new();
+
+        public (string RouteName, FhirRouteSettings Settings) ResolveRoute(string? shipService, string resourceType)
+        {
+            if (string.IsNullOrWhiteSpace(resourceType))
+                throw new ArgumentException("Resource type is required", nameof(resourceType));
+
+            if (!string.IsNullOrWhiteSpace(shipService))
+            {
+                var matchByName = Apis.FirstOrDefault(a =>
+                    string.Equals(a.Name, shipService, StringComparison.OrdinalIgnoreCase));
+                if (matchByName is not null)
+                    return (matchByName.Name, matchByName);
+            }
+
+            var matchByResource = Apis.FirstOrDefault(a => a.Resources.Any(r =>
+                string.Equals(r, resourceType, StringComparison.OrdinalIgnoreCase)));
+            if (matchByResource is not null)
+                return (matchByResource.Name, matchByResource);
+
+            return ("Default", Default ?? throw new InvalidOperationException("FhirRouting:Default is not configured"));
+        }
+    }
+
+    public class FhirRouteSettings
+    {
+        public string BaseUrl { get; set; } = default!;
+        public int TimeoutSeconds { get; set; } = 30;
+        public FhirClientCertificateSettings? ClientCert { get; set; }
+        public string? CallbackUrlTemplate { get; set; }
+        public string? Scope { get; set; }
+    }
+
+    public sealed class FhirApiRouteSettings : FhirRouteSettings
+    {
+        public string Name { get; set; } = default!;
+        public List<string> Resources { get; set; } = new();
+    }
+
+    public sealed class FhirClientCertificateSettings
+    {
+        public string Path { get; set; } = default!;
+        public string Password { get; set; } = default!;
+    }
+}

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Service/Ship.Ses.Transmitter.Worker/StatusProbeWorker.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Service/Ship.Ses.Transmitter.Worker/StatusProbeWorker.cs
@@ -113,6 +113,7 @@ namespace Ship.Ses.Transmitter.Worker
                     FhirOperation.Get,
                     resourceType: ev.ResourceType,
                     resourceId: ev.TransactionId,
+                    shipService: ev.ShipService,
                     cancellationToken: ct);
 
                 // Handle the two types of api responses:

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Service/Ship.Ses.Transmitter.Worker/appsettings.json
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Service/Ship.Ses.Transmitter.Worker/appsettings.json
@@ -70,19 +70,38 @@
         "MetricsFlushSeconds": 300,
         "UseShipAdminApi": true
     },
-    "FhirApi": {
-        "BaseUrl": "https://ship-patient-demographics-service.k9.isw.la/pds",
-        "ClientCertPath": "certs/client.pfx",
-        "ClientCertPassword": "changeit",
-        "TimeoutSeconds": 30,
-        "CallbackUrlTemplate": "https://{facility}.health.ng/ship/fhir/ack"
+    "FhirRouting": {
+        "Default": {
+            "BaseUrl": "https://ship-integration-gateway.k9.isw.la/fhir",
+            "TimeoutSeconds": 30,
+            "ClientCert": { "Path": "certs/client.pfx", "Password": "changeit" },
+            "Scope": "ship"
+        },
+        "Apis": [
+            {
+                "Name": "PDS",
+                "Resources": [ "Patient" ],
+                "BaseUrl": "https://ship-patient-demographics-service.k9.isw.la/pds",
+                "TimeoutSeconds": 30,
+                "ClientCert": { "Path": "certs/client.pfx", "Password": "changeit" },
+                "Scope": "ship.pds.write"
+            },
+            {
+                "Name": "ClinicalData",
+                "Resources": [ "Observation", "AllergyIntolerance", "Condition" ],
+                "BaseUrl": "https://ship-clinical-data-service.k9.isw.la/clinical",
+                "TimeoutSeconds": 45,
+                "ClientCert": { "Path": "certs/client.pfx", "Password": "changeit" },
+                "Scope": "ship.clinical.write"
+            }
+        ]
     },
     "AuthSettings": {
         "TokenEndpoint": "https://ship-identity-service.k9.isw.la/identity/api/v1/auth/token",
         "ClientId": "lakeshore",
         "ClientSecret": "0z4n9GKzHe585yu3O1YhTyJxo54XniW5",
         "GrantType": "client_credentials",
-        "Scope": "pds.create"
+        "Scope": "ship"
     },
     "ShipAdminApi": {
         "BaseUrl": "https://ship-admin-api.k9.isw.la",


### PR DESCRIPTION
## Summary
- add new FhirRouting configuration with per-service resource mappings and fallback for legacy FhirApi settings
- update FhirApiService, TokenService, and sync workers to route requests by ship service/resource and capture ship service on status events
- enable the generic ResourcesFhirSyncWorker and refresh appsettings to demonstrate multiple service endpoints

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68deba4c5044832d9e5d3d310546fd1f