### PR TITLE
Enable configurable multi-service FHIR routing

### DIFF
--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/Installers/WorkerServiceExtensions.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/Installers/WorkerServiceExtensions.cs
@@ -150,7 +150,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.Installers
             .AddPolicyHandler(GetRetryPolicy())
             .AddPolicyHandler(GetCircuitBreakerPolicy());
 
-            services.AddScoped<IFhirApiService, FhirApiService>();
+            services.AddSingleton<IFhirApiService, FhirApiService>();
 
             return services;
         }

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/Persistance/Configuration/Domain/MongoSyncRepository.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/Persistance/Configuration/Domain/MongoSyncRepository.cs
@@ -19,7 +19,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.Persistance.Configuration.Domain
     {
         private readonly IMongoDatabase _database;
         private IMongoCollection<StatusEvent> StatusEventCol =>
-        _database.GetCollection<StatusEvent>("patientstatusevents");
+        _database.GetCollection<StatusEvent>("fhirstatusevents");
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoSyncRepository"/> class.
         /// </summary>
@@ -116,7 +116,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.Persistance.Configuration.Domain
         /// <returns></returns>
         public async Task<List<StatusEvent>> FetchDueEmrCallbacksAsync(int batchSize, CancellationToken ct = default)
         {
-            var col = _database.GetCollection<StatusEvent>("patientstatusevents");
+            var col = _database.GetCollection<StatusEvent>("fhirstatusevents");
             var now = DateTime.UtcNow;
 
             var filter = Builders<StatusEvent>.Filter.And(
@@ -138,7 +138,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.Persistance.Configuration.Domain
         /// <returns></returns>
         public async Task<bool> TryMarkInFlightAsync(ObjectId id, CancellationToken ct = default)
         {
-            var col = _database.GetCollection<StatusEvent>("patientstatusevents");
+            var col = _database.GetCollection<StatusEvent>("fhirstatusevents");
             var now = DateTime.UtcNow;
 
             var filter = Builders<StatusEvent>.Filter.And(
@@ -167,7 +167,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.Persistance.Configuration.Domain
         /// <returns></returns>
         public async Task MarkEmrCallbackSucceededAsync(ObjectId id, int statusCode, string? body, string? targetUrl, CancellationToken ct = default)
         {
-            var col = _database.GetCollection<StatusEvent>("patientstatusevents");
+            var col = _database.GetCollection<StatusEvent>("fhirstatusevents");
             var update = Builders<StatusEvent>.Update
                 .Set(x => x.CallbackStatus, "Succeeded")
                 .Set(x => x.CallbackDeliveredAt, DateTime.UtcNow)
@@ -188,7 +188,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.Persistance.Configuration.Domain
         /// <returns></returns>
         public async Task MarkEmrCallbackRetryAsync(ObjectId id, string? error, TimeSpan delay, string? targetUrl, CancellationToken ct = default)
         {
-            var col = _database.GetCollection<StatusEvent>("patientstatusevents");
+            var col = _database.GetCollection<StatusEvent>("fhirstatusevents");
             var update = Builders<StatusEvent>.Update
                 .Inc(x => x.CallbackAttempts, 1)
                 .Set(x => x.CallbackStatus, "Pending")
@@ -273,7 +273,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.Persistance.Configuration.Domain
     BsonDocument? payload,
     CancellationToken ct = default)
         {
-            var col = _database.GetCollection<StatusEvent>("patientstatusevents");
+            var col = _database.GetCollection<StatusEvent>("fhirstatusevents");
 
             var update = Builders<StatusEvent>.Update
                 .Set(x => x.Status, "SUCCESS")

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/ReadServices/FhirSyncService.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Infrastructure/ReadServices/FhirSyncService.cs
@@ -67,7 +67,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.ReadServices
             {
                 try
                 {
-                    //disable callback for now
+                    //this is SeS callback URL, not the EMR one
                     //var callbackUrl = _apiSettings.CurrentValue.CallbackUrlTemplate;
                     //if (string.IsNullOrWhiteSpace(callbackUrl))
                     //    throw new InvalidOperationException("FhirApi:CallbackUrlTemplate is missing or produced an empty URL.");
@@ -81,7 +81,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.ReadServices
                         record.ResourceType,
                         record.ResourceId,
                         record.FhirJson.ToCleanJson(),
-                        record.ClientEMRCallbackUrl,
+                        "", // we will evaluate the callback URL on the api side
                         record.ShipService,
                         token);
 

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Service/Ship.Ses.Transmitter.Worker/appsettings.json
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Service/Ship.Ses.Transmitter.Worker/appsettings.json
@@ -74,8 +74,12 @@
         "Default": {
             "BaseUrl": "https://ship-integration-gateway.k9.isw.la/fhir",
             "TimeoutSeconds": 30,
-            "ClientCert": { "Path": "certs/client.pfx", "Password": "changeit" },
-            "Scope": "ship"
+            "ClientCert": {
+                "Path": "certs/client.pfx",
+                "Password": "changeit"
+            },
+            "Scope": "ship",
+            "CallbackUrlTemplate": "https://ship-integration-gateway.k9.isw.la/fhir/callback/"
         },
         "Apis": [
             {
@@ -83,16 +87,22 @@
                 "Resources": [ "Patient" ],
                 "BaseUrl": "https://ship-patient-demographics-service.k9.isw.la/pds",
                 "TimeoutSeconds": 30,
-                "ClientCert": { "Path": "certs/client.pfx", "Password": "changeit" },
-                "Scope": "ship.pds.write"
+                "ClientCert": {
+                    "Path": "certs/client.pfx",
+                    "Password": "changeit"
+                },
+                "Scope": "ship-full-access"
             },
             {
-                "Name": "ClinicalData",
+                "Name": "SCR",
                 "Resources": [ "Observation", "AllergyIntolerance", "Condition" ],
-                "BaseUrl": "https://ship-clinical-data-service.k9.isw.la/clinical",
+                "BaseUrl": "https://ship-scr-service.k8.isw.la/api/v1/Encounter",
                 "TimeoutSeconds": 45,
-                "ClientCert": { "Path": "certs/client.pfx", "Password": "changeit" },
-                "Scope": "ship.clinical.write"
+                "ClientCert": {
+                    "Path": "certs/client.pfx",
+                    "Password": "changeit"
+                },
+                "Scope": "ship-full-access"
             }
         ]
     },


### PR DESCRIPTION
add new FhirRouting configuration with per-service resource mappings and fallback for legacy FhirApi settings
update FhirApiService, TokenService, and sync workers to route requests by ship service/resource and capture ship service on status events
enable the generic ResourcesFhirSyncWorker and refresh appsettings to demonstrate multiple service endpoints