### PR TITLE
Route non-patient queue items to their SHIP services

### DIFF
--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Application/Interfaces/IFhirSyncService.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Application/Interfaces/IFhirSyncService.cs
@@ -12,7 +12,7 @@ namespace Ship.Ses.Transmitter.Application.Interfaces
     {
         //Task ProcessPendingRecordsAsync(FhirResourceType resourceType, CancellationToken cancellationToken);
         //Task ProcessPendingRecordsAsync<T>(CancellationToken token) where T : FhirSyncRecord, new();
-        Task<SyncResultDto> ProcessPendingRecordsAsync<T>(CancellationToken token) 
-    where T : FhirSyncRecord, new();
+        Task<SyncResultDto> ProcessPendingRecordsAsync<T>(CancellationToken token, string? resourceName = null)
+            where T : FhirSyncRecord, new();
     }
 }

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Domain/Patients/FhirResourceAttribute.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Domain/Patients/FhirResourceAttribute.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Ship.Ses.Transmitter.Domain.Patients
 {
     //explicit resource naming for discovery
-    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
     public sealed class FhirResourceAttribute : Attribute
     {
         public string ResourceName { get; }

--- a/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Domain/Queue/QueueSyncRecord.cs
+++ b/Ship.Ses.Transmitter/src/Ship.Ses.Transmitter.Domain/Queue/QueueSyncRecord.cs
@@ -1,0 +1,17 @@
+using Ship.Ses.Transmitter.Domain.Patients;
+
+namespace Ship.Ses.Transmitter.Domain.Queue
+{
+    [FhirResource("Observation")]
+    [FhirResource("AllergyIntolerance")]
+    [FhirResource("Condition")]
+    public sealed class QueueSyncRecord : FhirSyncRecord
+    {
+        public override string CollectionName => "transformed_pool_queue";
+
+        public QueueSyncRecord()
+        {
+            ResourceType = string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `FhirResourceAttribute` and discovery logic so one record type can advertise multiple FHIR resources and add a queue-backed record for Observation/AllergyIntolerance/Condition payloads
- pass the requested resource name into `IFhirSyncService.ProcessPendingRecordsAsync` and filter Mongo results so only items for that resource are submitted to the correct SHIP service
- keep logging in sync with the filtered resource name to surface accurate routing details during sync runs

## Testing
- `dotnet build` *(fails: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1961620fc832db0fb155eec1d22cd